### PR TITLE
Add option to omit merge request description (closes #5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,13 @@ If the commits should be listed when code is pushed.
 GITLAB_SHOW_COMMITS_LIST=0
 ```
 
+#####GITLAB_SHOW_MERGE_DESCRIPTION
+
+If the the merge request hook should also show the description. Useful for adapters like IRC where long descriptions can spam the channel
+
+```
+GITLAB_SHOW_MERGE_DESCRIPTION=0
+```
 
 ##Query Params
 

--- a/src/gitlab.coffee
+++ b/src/gitlab.coffee
@@ -9,6 +9,8 @@
 #   GITLAB_CHANNEL
 #   GITLAB_DEBUG
 #   GITLAB_BRANCHES
+#   GITLAB_SHOW_COMMITS_LISTG
+#   GITLAB_SHOW_MERGE_DESCRIPTION
 #
 #   Put http://<HUBOT_URL>:<PORT>/gitlab/system as your system hook
 #   Put http://<HUBOT_URL>:<PORT>/gitlab/web as your web hook (per repository)

--- a/src/gitlab.coffee
+++ b/src/gitlab.coffee
@@ -37,6 +37,7 @@ querystring = require 'querystring'
 module.exports = (robot) ->
   gitlabChannel = process.env.GITLAB_CHANNEL or "#gitlab"
   showCommitsList = process.env.GITLAB_SHOW_COMMITS_LIST or "1"
+  showMergeDesc = process.env.GITLAB_SHOW_MERGE_DESCRIPTION or "1"
   debug = process.env.GITLAB_DEBUG?
   branches = ['all']
   if process.env.GITLAB_BRANCHES?
@@ -130,7 +131,10 @@ module.exports = (robot) ->
                   text += "\r\n" + splitted.join "\r\n"
                 robot.send user, text
             when "merge_request"
-              robot.send user, "Merge Request #{bold(hook.object_attributes.iid)}: #{hook.object_attributes.title} (#{hook.object_attributes.state}) between #{bold(hook.object_attributes.source_branch)} and #{bold(hook.object_attributes.target_branch)} \n>> #{hook.object_attributes.description}"
+              if showMergeDesc == "1"  
+                robot.send user, "Merge Request #{bold(hook.object_attributes.iid)}: #{hook.object_attributes.title} (#{hook.object_attributes.state}) between #{bold(hook.object_attributes.source_branch)} and #{bold(hook.object_attributes.target_branch)} \n>> #{hook.object_attributes.description}"
+              else
+                robot.send user, "Merge Request #{bold(hook.object_attributes.iid)}: #{hook.object_attributes.title} (#{hook.object_attributes.state}) between #{bold(hook.object_attributes.source_branch)} and #{bold(hook.object_attributes.target_branch)}"
 
   robot.router.post "/gitlab/system", (req, res) ->
     handler "system", req, res


### PR DESCRIPTION
Proper a nicer cleaner way to do this, but it gets the job done