### PR TITLE
Improve message on new commits

### DIFF
--- a/src/gitlab.coffee
+++ b/src/gitlab.coffee
@@ -115,7 +115,7 @@ module.exports = (robot) ->
                 if showCommitsList == "1"
                   merger = []
                   for i in [0...hook.commits.length]
-                    merger[i] = ">> Commit " + (i+1) + ": " + hook.commits[i].message
+                    merger[i] = "> " + hook.commits[i].id.slice(0,7) + ": " + hook.commits[i].message.replace /\n.*$/gm, ''
                   message += "\r\n" + merger.join "\r\n"
           robot.send user, message
         # not code? must be a something good!


### PR DESCRIPTION
Solves #12 

Three changes in one line (yay):

* Show short form of commit id instead of "Commit 1"
* Show only first line for multiline commit messages
* Use markdown-compatible syntax (exactly one ">" at the beginning of each line)