### PR TITLE
Fix typo in merge request notification

### DIFF
--- a/src/gitlab.coffee
+++ b/src/gitlab.coffee
@@ -145,14 +145,14 @@ module.exports = (robot) ->
             when "merge_request"
               unless hook.object_attributes.action == "update"
                 if showMergeDesc == "1"  
-                  text = "Merge Request #{bold(hook.object_attributes.iid)}: #{hook.user.username} #{hook.object_attributes.action}ed  #{hook.object_attributes.title} between #{bold(hook.object_attributes.source_branch)} and #{bold(hook.object_attributes.target_branch)} at #{bold(hook.object_attributes.url)}\n"
+                  text = "Merge Request #{bold(hook.object_attributes.iid)}: #{hook.user.username} #{hook.object_attributes.action}  #{hook.object_attributes.title} between #{bold(hook.object_attributes.source_branch)} and #{bold(hook.object_attributes.target_branch)} at #{bold(hook.object_attributes.url)}\n"
                   splitted = hook.object_attributes.description.split  "\r\n"
                   for i in [0...splitted.length]
                     splitted[i] = "> " + splitted[i]
                   text += "\r\n" + splitted.join "\r\n"
                   robot.send user, text
                 else
-                  robot.send user, "Merge Request #{bold(hook.object_attributes.iid)}: #{hook.user.username} #{hook.object_attributes.action}ed  #{hook.object_attributes.title} (#{hook.object_attributes.state}) between #{bold(hook.object_attributes.source_branch)} and #{bold(hook.object_attributes.target_branch)} at #{bold(hook.object_attributes.url)}"
+                  robot.send user, "Merge Request #{bold(hook.object_attributes.iid)}: #{hook.user.username} #{hook.object_attributes.action}  #{hook.object_attributes.title} (#{hook.object_attributes.state}) between #{bold(hook.object_attributes.source_branch)} and #{bold(hook.object_attributes.target_branch)} at #{bold(hook.object_attributes.url)}"
 
   robot.router.post "/gitlab/system", (req, res) ->
     handler "system", req, res


### PR DESCRIPTION
Adding an extra 'ed' to the end of `#{hook.object_attributes.action}` results in a spelling mistake:
`Merge Request 12: samurailink3 mergeed Merge Title`