### PR TITLE
Adding configuration for GITLAB_URL to enable actions back to the server

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Via Environment- variables or via query params:
 
 ##ENV
 
-#####GITLAB_CHANNEL
+#####GITLAB_URL
 
 The URL of your GitLab installation: http://git.example.com/
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ Via Environment- variables or via query params:
 
 #####GITLAB_CHANNEL
 
+The URL of your GitLab installation: http://git.example.com/
+
+#####GITLAB_CHANNEL
+
 The Room to which the gitlab messages get published. Use like this:
 
 For HipChat

--- a/src/gitlab.coffee
+++ b/src/gitlab.coffee
@@ -6,6 +6,7 @@
 #   "querystring" : ""
 #
 # Configuration:
+#   GITLAB_URL
 #   GITLAB_CHANNEL
 #   GITLAB_DEBUG
 #   GITLAB_BRANCHES
@@ -177,7 +178,7 @@ module.exports = (robot) ->
         ref: ref
 
     })
-    robot.http("http://code.cropcircle.io/api/v3/projects/"+project_id+"/trigger/builds")
+    robot.http(GITLAB_URL+"/api/v3/projects/"+project_id+"/trigger/builds")
         .header('Content-Type', 'application/json')
         .post(data) (err, res, body) ->
           # your code here    


### PR DESCRIPTION
Accidentally had my server config in the code. Now it uses GITLAB_URL.