### PR TITLE
Fix null merge request description error

### DIFF
--- a/src/gitlab.coffee
+++ b/src/gitlab.coffee
@@ -146,7 +146,7 @@ module.exports = (robot) ->
               unless hook.object_attributes.action == "update"
                 if showMergeDesc == "1"  
                   text = "Merge Request #{bold(hook.object_attributes.iid)}: #{hook.user.username} #{hook.object_attributes.action}  #{hook.object_attributes.title} between #{bold(hook.object_attributes.source_branch)} and #{bold(hook.object_attributes.target_branch)} at #{bold(hook.object_attributes.url)}\n"
-                  splitted = hook.object_attributes.description.split  "\r\n"
+                  splitted = "${hook.object_attributes.description}".split  "\r\n"
                   for i in [0...splitted.length]
                     splitted[i] = "> " + splitted[i]
                   text += "\r\n" + splitted.join "\r\n"


### PR DESCRIPTION
When creating an MR via GitLab API, it's possible for the description field to be null instead of a string.